### PR TITLE
Fix get album and track image from Spotify

### DIFF
--- a/maloja/thirdparty/__init__.py
+++ b/maloja/thirdparty/__init__.py
@@ -232,13 +232,19 @@ class MetadataInterface(GenericInterface, abstract=True):
         if self.metadata["response_type"] == "json":
             data = response.json()
             if "response_parse_track_items" in self.metadata:
-                # Match track item by track name
+                # Match track item by track/album name and artist name
                 imgurl = None
                 for item in self._parse_response("response_parse_track_items", data):
                     track_name = self._parse_response(
                         "response_parse_track_item_track_name", item
                     )
-                    if track_name == title:
+                    album_name = self._parse_response(
+                        "response_parse_track_item_album_name", item
+                    )
+                    artist_name = self._parse_response(
+                        "response_parse_track_item_artist_name", item
+                    )
+                    if title in [track_name, album_name] and artist_name in artists:
                         imgurl = self._parse_response(
                             "response_parse_track_item_imgurl", item
                         )
@@ -294,7 +300,7 @@ class MetadataInterface(GenericInterface, abstract=True):
         if self.metadata["response_type"] == "json":
             data = response.json()
             if "response_parse_album_items" in self.metadata:
-                # Match album item by artist and album name
+                # Match album item by album name and artist name
                 imgurl = None
                 for item in self._parse_response("response_parse_album_items", data):
                     artist_name = self._parse_response(
@@ -303,7 +309,7 @@ class MetadataInterface(GenericInterface, abstract=True):
                     album_name = self._parse_response(
                         "response_parse_album_item_name", item
                     )
-                    if artist_name in artists and album_name == title:
+                    if title == album_name and artist_name in artists:
                         imgurl = self._parse_response(
                             "response_parse_album_item_imgurl", item
                         )

--- a/maloja/thirdparty/spotify.py
+++ b/maloja/thirdparty/spotify.py
@@ -14,7 +14,7 @@ class Spotify(MetadataInterface):
 
     metadata = {
         "trackurl": "https://api.spotify.com/v1/search?q={title}%2520artist%3A{artist}&type=track&access_token={token}&limit=50",
-        "albumurl": "https://api.spotify.com/v1/search?q={title}%2520artist%3A{artist}&type=album&access_token={token}&limit=50",
+        "albumurl": "https://api.spotify.com/v1/search?q={title}%2520artist%3A{artist}&type=album&access_token={token}&limit=50&market=JP",
         "artisturl": "https://api.spotify.com/v1/search?q={artist}&type=artist&access_token={token}&limit=50",
         "response_type": "json",
         "response_parse_tree_track": [

--- a/maloja/thirdparty/spotify.py
+++ b/maloja/thirdparty/spotify.py
@@ -30,6 +30,8 @@ class Spotify(MetadataInterface):
         "response_parse_tree_artist": ["artists", "items", 0, "images", 0, "url"],
         "response_parse_track_items": ["tracks", "items"],
         "response_parse_track_item_track_name": ["name"],
+        "response_parse_track_item_album_name": ["album", "name"],
+        "response_parse_track_item_artist_name": ["artists", 0, "name"],
         "response_parse_track_item_imgurl": ["album", "images", 0, "url"],
         "response_parse_artist_items": ["artists", "items"],
         "response_parse_artist_item_artist_name": ["name"],


### PR DESCRIPTION
- Add `market=JP` parameter to Spotify album search URL
- Match track image by album name and artist name
